### PR TITLE
Upgrade @aantron/repromise to reason-promise

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -5,7 +5,7 @@
   "bs-dependencies": [
     "reason-react",
     "gatsby-link-reason",
-    "@aantron/repromise",
+    "reason-promise",
     "@jsiebern/bs-material-ui"
   ],
   "sources": [

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "version": "0.1.0",
   "author": "Jeremy Berglund",
   "dependencies": {
-    "@aantron/repromise": "^0.6.0",
     "@jsiebern/bs-material-ui": "^0.4.2",
     "@material-ui/core": "^3.2.1",
     "@material-ui/icons": "^3.0.1",
@@ -17,7 +16,7 @@
     "@uppy/url": "^0.27.5",
     "@uppy/webcam": "^0.27.4",
     "@uppy/xhr-upload": "^0.27.4",
-    "bs-platform": "^4.0.6",
+    "bs-platform": "^7.0.1",
     "gatsby": "^2.0.0-rc.28",
     "gatsby-link": "^2.0.0-rc.4",
     "gatsby-link-reason": "^1.1.0",
@@ -26,6 +25,7 @@
     "ipfs-api": "^24.0.2",
     "react-helmet": "^5.2.0",
     "react-jss": "^8.6.1",
+    "reason-promise": "^1.0.2",
     "reason-react": "^0.5.3"
   },
   "repository": {

--- a/src/components/App.re
+++ b/src/components/App.re
@@ -343,11 +343,11 @@ let make = (~data, _children) => {
                                    ThreeBox.web3##eth##accounts[0],
                                    ThreeBox.web3##currentProvider,
                                  )
-                                 |> Repromise.andThen(value => {
+                                 ->Promise.flatMap(value => {
                                       self.send(SetThreeBox(value));
-                                      Repromise.resolved(value);
+                                      Promise.resolved(value);
                                     })
-                                 |> Repromise.wait(box => {
+                                 ->Promise.get(box => {
                                       Js.log(box);
                                       self.send(SetLoggingIn(false));
                                     });

--- a/src/lib/ThreeBox.re
+++ b/src/lib/ThreeBox.re
@@ -7,6 +7,6 @@ type web3 = {
 };
 [@bs.val] external web3: web3 = "window.web3";
 [@bs.val "window.ThreeBox.openBox"]
-external openBox: (string, web3Provider) => Repromise.t(threeBox) = "";
+external openBox: (string, web3Provider) => Promise.t(threeBox) = "";
 
 [@bs.send] external logout: threeBox => unit = "logout";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,11 +2,6 @@
 # yarn lockfile v1
 
 
-"@aantron/repromise@^0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@aantron/repromise/-/repromise-0.6.0.tgz#45bea66e593b7e0f968bc0fd03f0b6578003e698"
-  integrity sha512-nxNUWKQQhRJKmsExKi2qyZUryvpEz07H17fEhRaZC3wXkxCtjcdx9j5LMnV0+anbU+EyG/X+UnfATReerBZgMA==
-
 "@babel/code-frame@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "http://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz#2a02643368de80916162be70865c97774f3adbd9"
@@ -2567,10 +2562,10 @@ bs-loader@^2.0.5:
     loader-utils "^1.1.0"
     read-bsconfig "^1.0.1"
 
-bs-platform@^4.0.6:
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-4.0.6.tgz#e7f156c77ad3efafb0c0291b41dcf1b06f93c192"
-  integrity sha512-TrNzQFoV6opBYdUgcRdgQQ5f6JnKgotPFZORIjuHPtRlYgv37P6xVBTGfA4NlMCkHXHcPrL6JI63GyAcfq+qpg==
+bs-platform@^7.0.1:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-7.1.0.tgz#72b52148b1c4be7f878969e6e2afd1bfab068cdd"
+  integrity sha512-XUeZf1nGzmsVymG89j5L8G9YNDHl0J/5iDGExXA7a4RKxnbvP2TselBZAzFeEH4rs3gG01b7yKt+h2pm7yh7Ww==
 
 bs58@4.0.1, bs58@^4.0.1:
   version "4.0.1"
@@ -9053,6 +9048,11 @@ readdirp@^2.0.0:
     graceful-fs "^4.1.11"
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
+
+reason-promise@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/reason-promise/-/reason-promise-1.0.2.tgz#22b9bb4097ce511190182b948aef11427d5b8b86"
+  integrity sha512-j8DWV+71wNEKQmyW6zBOowIZq1Qec5CDWyLI37BvgOmAZgRFGFQ1MaJnbhqDe3JsYmaGyqdNMmpCJLl9EDbDAg==
 
 reason-react@^0.4.2:
   version "0.4.2"


### PR DESCRIPTION
Repromise became [**reason-promise**](https://github.com/aantron/promise) in 1.0.0. The API was renamed (e.g., `Repromise.wait` is now `Promise.get`), rearranged to prefer `->` instead of `|>`, and helpers were added for `Result` and `Option`, as well as some miscellaneous ones. The bundle size was reduced to 1K. See the [changelog](https://github.com/aantron/promise/releases/tag/1.0.0) here; there are also two subsequent bugfix releases.